### PR TITLE
fixed build and fit issue in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,14 @@
 *.tlog
 *.tmp
 *.VC.db
+
+Bin/
+SbieDebug
+SbieRelease
+MsgSbieRelease
+*.log
+**/*_h.h
+**/*_i.c
+**/*_p.c
+msgs/msgs.mc
+**/*-1033.txt

--- a/Sandbox32.props
+++ b/Sandbox32.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <WDKPATH>\WinDDK\7600.16385.1</WDKPATH>
+    <WDKPATH>C:\WinDDK\7600.16385.1</WDKPATH>
   </PropertyGroup>
   <PropertyGroup>
     <IncludePath>..\;..\..\;..\..\..\;$(VCInstallDir)include;$(WindowsSDK_IncludePath);$(VCInstallDir)atlmfc\include;$(IncludePath)</IncludePath>

--- a/Sandbox64.props
+++ b/Sandbox64.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <WDKPATH>\WinDDK\7600.16385.1</WDKPATH>
+    <WDKPATH>C:\WinDDK\7600.16385.1</WDKPATH>
   </PropertyGroup>
   <PropertyGroup>
     <IncludePath>..\;..\..\;..\..\..\;$(VCInstallDir)include;$(WindowsSDK_IncludePath);$(VCInstallDir)atlmfc\include;$(IncludePath)</IncludePath>


### PR DESCRIPTION
Was not being able to compile, I changed the WDK path in the files sandbox32.props and sandbox64.props. For the files generated in the build, I adjusted the .gitignore file. It was possible to compile in Visual Studio Community 2015 and 2017 in my tests.